### PR TITLE
D9: Add core_version_requirement: ^8 || ^9

### DIFF
--- a/test_decorator_a/test_decorator_a.info.yml
+++ b/test_decorator_a/test_decorator_a.info.yml
@@ -3,5 +3,6 @@ type: module
 description: 'Single Decorator.'
 package: Development
 core: 8.x
+core_version_requirement: ^8 || ^9
 dependencies:
   - test_decorator_core

--- a/test_decorator_chain/test_decorator_chain.info.yml
+++ b/test_decorator_chain/test_decorator_chain.info.yml
@@ -3,5 +3,6 @@ type: module
 description: 'A decorator that chains onto another.'
 package: Development
 core: 8.x
+core_version_requirement: ^8 || ^9
 dependencies:
   - test_decorator_core

--- a/test_decorator_core/test_decorator_core.info.yml
+++ b/test_decorator_core/test_decorator_core.info.yml
@@ -3,3 +3,4 @@ type: module
 description: 'Test how service decorators work. Core service.'
 package: Development
 core: 8.x
+core_version_requirement: ^8 || ^9

--- a/test_decorator_higher/test_decorator_higher.info.yml
+++ b/test_decorator_higher/test_decorator_higher.info.yml
@@ -3,5 +3,6 @@ type: module
 description: 'Decorator with higher priority.'
 package: Development
 core: 8.x
+core_version_requirement: ^8 || ^9
 dependencies:
   - test_decorator_core

--- a/test_decorator_inter/test_decorator_inter.info.yml
+++ b/test_decorator_inter/test_decorator_inter.info.yml
@@ -3,5 +3,6 @@ type: module
 description: 'Test decorator with object interface instead of extend.'
 package: Development
 core: 8.x
+core_version_requirement: ^8 || ^9
 dependencies:
   - test_decorator_core

--- a/test_decorator_lower/test_decorator_lower.info.yml
+++ b/test_decorator_lower/test_decorator_lower.info.yml
@@ -3,5 +3,6 @@ type: module
 description: 'Test decorator with lower priority.'
 package: Development
 core: 8.x
+core_version_requirement: ^8 || ^9
 dependencies:
   - test_decorator_core

--- a/test_decorator_protect/test_decorator_protect.info.yml
+++ b/test_decorator_protect/test_decorator_protect.info.yml
@@ -3,5 +3,6 @@ type: module
 description: 'Override protected method via decorator.'
 package: Development
 core: 8.x
+core_version_requirement: ^8 || ^9
 dependencies:
   - test_decorator_core


### PR DESCRIPTION
Add `core_version_requirement: ^8 || ^9` in all the `*.info.yml` files for D9 compatibility.